### PR TITLE
call unsuspend callback when stopping at a breakpoint

### DIFF
--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -1104,8 +1104,9 @@ type LogicalBreakpoint struct {
 	// condUsesHitCounts is true when 'cond' uses breakpoint hitcounts
 	condUsesHitCounts bool
 
-	DidUnsuspend func(*LogicalBreakpoint) // A function that is called if the breakpoint is unsuspended
-	UserData     interface{}              // Any additional information about the breakpoint
+	Unsuspended       bool        // Whether the breakpoint is unsuspended
+	UnsuspendCallback func()      // A function that is called if the breakpoint is unsuspended
+	UserData          interface{} // Any additional information about the breakpoint
 	// Name of root function from where tracing needs to be done
 	RootFuncName string
 	// depth of tracing

--- a/pkg/proc/breakpoints.go
+++ b/pkg/proc/breakpoints.go
@@ -1104,7 +1104,8 @@ type LogicalBreakpoint struct {
 	// condUsesHitCounts is true when 'cond' uses breakpoint hitcounts
 	condUsesHitCounts bool
 
-	UserData interface{} // Any additional information about the breakpoint
+	DidUnsuspend func(*LogicalBreakpoint) // A function that is called if the breakpoint is unsuspended
+	UserData     interface{}              // Any additional information about the breakpoint
 	// Name of root function from where tracing needs to be done
 	RootFuncName string
 	// depth of tracing

--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -584,9 +584,10 @@ func (t *Target) pluginOpenCallback(Thread, *Target) (bool, error) {
 				logger.Debugf("could not enable breakpoint %d: %v", lbp.LogicalID, err)
 			} else {
 				logger.Debugf("suspended breakpoint %d enabled", lbp.LogicalID)
-			}
-			if lbp.DidUnsuspend != nil {
-				lbp.DidUnsuspend(lbp)
+				if !lbp.Unsuspended && lbp.UnsuspendCallback != nil {
+					lbp.UnsuspendCallback()
+					lbp.Unsuspended = true
+				}
 			}
 		}
 	}

--- a/pkg/proc/target.go
+++ b/pkg/proc/target.go
@@ -585,6 +585,9 @@ func (t *Target) pluginOpenCallback(Thread, *Target) (bool, error) {
 			} else {
 				logger.Debugf("suspended breakpoint %d enabled", lbp.LogicalID)
 			}
+			if lbp.DidUnsuspend != nil {
+				lbp.DidUnsuspend(lbp)
+			}
 		}
 	}
 	return false, nil

--- a/pkg/proc/target_exec.go
+++ b/pkg/proc/target_exec.go
@@ -256,6 +256,11 @@ func (grp *TargetGroup) Continue() error {
 			}
 			if curbp.LogicalID() != hardcodedBreakpointID {
 				dbp.StopReason = StopBreakpoint
+				curlbp := curbp.Breakpoint.Logical
+				if !curlbp.Unsuspended && curlbp.UnsuspendCallback != nil {
+					curlbp.UnsuspendCallback()
+					curlbp.Unsuspended = true
+				}
 			}
 			if curbp.Breakpoint.WatchType != 0 {
 				dbp.StopReason = StopWatchpoint

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -132,7 +132,8 @@ type Breakpoint struct {
 	// Disabled flag, signifying the state of the breakpoint
 	Disabled bool `json:"disabled"`
 
-	UserData interface{} `json:"-"`
+	UserData     interface{}       `json:"-"`
+	DidUnsuspend func(*Breakpoint) `json:"-"`
 
 	// RootFuncName is the Root function from where tracing needs to be done
 	RootFuncName string

--- a/service/api/types.go
+++ b/service/api/types.go
@@ -132,8 +132,7 @@ type Breakpoint struct {
 	// Disabled flag, signifying the state of the breakpoint
 	Disabled bool `json:"disabled"`
 
-	UserData     interface{}       `json:"-"`
-	DidUnsuspend func(*Breakpoint) `json:"-"`
+	UserData interface{} `json:"-"`
 
 	// RootFuncName is the Root function from where tracing needs to be done
 	RootFuncName string

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1522,20 +1522,26 @@ func (s *Session) setBreakpoints(prefix string, totalBps int, metadataFunc func(
 				err = errors.New("breakpoint already exists")
 			} else {
 				bp := &api.Breakpoint{
-					Name:    want.name,
-					File:    wantLoc.file,
-					Line:    wantLoc.line,
-					Addr:    wantLoc.addr,
-					Addrs:   wantLoc.addrs,
-					Cond:    want.condition,
-					HitCond: want.hitCondition,
+					Name:         want.name,
+					File:         wantLoc.file,
+					Line:         wantLoc.line,
+					Addr:         wantLoc.addr,
+					Addrs:        wantLoc.addrs,
+					Cond:         want.condition,
+					HitCond:      want.hitCondition,
+					DidUnsuspend: s.didUnsuspendBreakpoint,
 				}
 				err = setLogMessage(bp, want.logMessage)
 				if err == nil {
 					// Create new breakpoints.
-					got, err = s.debugger.CreateBreakpoint(bp, "", nil, false)
+					got, err = s.debugger.CreateBreakpoint(bp, "", nil, true)
 				}
 			}
+		}
+		if len(got.Addrs) == 0 {
+			// Handle suspended breakpoints.
+			got.File = wantLoc.file
+			got.Line = wantLoc.line
 		}
 		createdBps[want.name] = struct{}{}
 		s.updateBreakpointsResponse(breakpoints, i, err, got)
@@ -1556,7 +1562,11 @@ func setLogMessage(bp *api.Breakpoint, msg string) error {
 }
 
 func (s *Session) updateBreakpointsResponse(breakpoints []dap.Breakpoint, i int, err error, got *api.Breakpoint) {
-	breakpoints[i].Verified = err == nil
+	if len(got.Addrs) > 0 {
+		breakpoints[i].Verified = true
+	} else {
+		breakpoints[i].Message = "Unable to set breakpoint"
+	}
 	if err != nil {
 		breakpoints[i].Message = err.Error()
 	} else {
@@ -1565,6 +1575,22 @@ func (s *Session) updateBreakpointsResponse(breakpoints []dap.Breakpoint, i int,
 		breakpoints[i].Line = got.Line
 		breakpoints[i].Source = &dap.Source{Name: filepath.Base(path), Path: path}
 	}
+}
+
+func (s *Session) didUnsuspendBreakpoint(bp *api.Breakpoint) {
+	path := s.toClientPath(bp.File)
+	s.send(&dap.BreakpointEvent{
+		Event: *newEvent("breakpoint"),
+		Body: dap.BreakpointEventBody{
+			Reason: "changed",
+			Breakpoint: dap.Breakpoint{
+				Verified: true,
+				Id:       bp.ID,
+				Line:     bp.Line,
+				Source:   &dap.Source{Name: filepath.Base(path), Path: path},
+			},
+		},
+	})
 }
 
 // functionBpPrefix is the prefix of bp.Name for every breakpoint bp set

--- a/service/dap/server.go
+++ b/service/dap/server.go
@@ -1522,23 +1522,22 @@ func (s *Session) setBreakpoints(prefix string, totalBps int, metadataFunc func(
 				err = errors.New("breakpoint already exists")
 			} else {
 				bp := &api.Breakpoint{
-					Name:         want.name,
-					File:         wantLoc.file,
-					Line:         wantLoc.line,
-					Addr:         wantLoc.addr,
-					Addrs:        wantLoc.addrs,
-					Cond:         want.condition,
-					HitCond:      want.hitCondition,
-					DidUnsuspend: s.didUnsuspendBreakpoint,
+					Name:    want.name,
+					File:    wantLoc.file,
+					Line:    wantLoc.line,
+					Addr:    wantLoc.addr,
+					Addrs:   wantLoc.addrs,
+					Cond:    want.condition,
+					HitCond: want.hitCondition,
 				}
 				err = setLogMessage(bp, want.logMessage)
 				if err == nil {
 					// Create new breakpoints.
-					got, err = s.debugger.CreateBreakpoint(bp, "", nil, true)
+					got, err = s.debugger.CreateBreakpoint(bp, "", nil, true, s.didUnsuspendBreakpoint)
 				}
 			}
 		}
-		if len(got.Addrs) == 0 {
+		if err != nil && err.Error() == "suspended breakpoint" {
 			// Handle suspended breakpoints.
 			got.File = wantLoc.file
 			got.Line = wantLoc.line
@@ -1562,12 +1561,8 @@ func setLogMessage(bp *api.Breakpoint, msg string) error {
 }
 
 func (s *Session) updateBreakpointsResponse(breakpoints []dap.Breakpoint, i int, err error, got *api.Breakpoint) {
-	if len(got.Addrs) > 0 {
-		breakpoints[i].Verified = true
-	} else {
-		breakpoints[i].Message = "Unable to set breakpoint"
-	}
-	if err != nil {
+	breakpoints[i].Verified = err == nil
+	if err != nil && err.Error() != "suspended breakpoint" {
 		breakpoints[i].Message = err.Error()
 	} else {
 		path := s.toClientPath(got.File)
@@ -1575,6 +1570,8 @@ func (s *Session) updateBreakpointsResponse(breakpoints []dap.Breakpoint, i int,
 		breakpoints[i].Line = got.Line
 		breakpoints[i].Source = &dap.Source{Name: filepath.Base(path), Path: path}
 	}
+	// TODO For DAP v1.68.0, Reason can be set to "pending" when a breakpoint is suspended.
+	// But it seems that nothing different happens.
 }
 
 func (s *Session) didUnsuspendBreakpoint(bp *api.Breakpoint) {

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -800,6 +800,13 @@ func (d *Debugger) CreateBreakpoint(requestedBp *api.Breakpoint, locExpr string,
 
 	createdBp := d.convertBreakpoint(lbp)
 	d.log.Infof("created breakpoint: %#v", createdBp)
+
+	if requestedBp.DidUnsuspend != nil {
+		lbp.DidUnsuspend = func(*proc.LogicalBreakpoint) {
+			requestedBp.DidUnsuspend(createdBp)
+		}
+	}
+
 	return createdBp, nil
 }
 

--- a/service/debugger/debugger.go
+++ b/service/debugger/debugger.go
@@ -673,7 +673,7 @@ func (d *Debugger) state(retLoadCfg *proc.LoadConfig, withBreakpointInfo bool) (
 // If suspended is true a logical breakpoint will be created even if the
 // location can not be found, the backend will attempt to enable the
 // breakpoint every time a new plugin is loaded.
-func (d *Debugger) CreateBreakpoint(requestedBp *api.Breakpoint, locExpr string, substitutePathRules [][2]string, suspended bool) (*api.Breakpoint, error) {
+func (d *Debugger) CreateBreakpoint(requestedBp *api.Breakpoint, locExpr string, substitutePathRules [][2]string, suspended bool, unsuspendCallback func(*api.Breakpoint)) (*api.Breakpoint, error) {
 	d.targetMutex.Lock()
 	defer d.targetMutex.Unlock()
 
@@ -792,6 +792,7 @@ func (d *Debugger) CreateBreakpoint(requestedBp *api.Breakpoint, locExpr string,
 	if err != nil {
 		if suspended {
 			logflags.DebuggerLogger().Debugf("could not enable new breakpoint: %v (breakpoint will be suspended)", err)
+			err = errors.New("suspended breakpoint")
 		} else {
 			delete(d.target.LogicalBreakpoints, lbp.LogicalID)
 			return nil, err
@@ -801,13 +802,13 @@ func (d *Debugger) CreateBreakpoint(requestedBp *api.Breakpoint, locExpr string,
 	createdBp := d.convertBreakpoint(lbp)
 	d.log.Infof("created breakpoint: %#v", createdBp)
 
-	if requestedBp.DidUnsuspend != nil {
-		lbp.DidUnsuspend = func(*proc.LogicalBreakpoint) {
-			requestedBp.DidUnsuspend(createdBp)
+	if err != nil && suspended {
+		lbp.UnsuspendCallback = func() {
+			unsuspendCallback(createdBp)
 		}
 	}
 
-	return createdBp, nil
+	return createdBp, err
 }
 
 func (d *Debugger) convertBreakpoint(lbp *proc.LogicalBreakpoint) *api.Breakpoint {

--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -260,8 +260,8 @@ func (s *RPCServer) CreateBreakpoint(arg CreateBreakpointIn, out *CreateBreakpoi
 	if err := api.ValidBreakpointName(arg.Breakpoint.Name); err != nil {
 		return err
 	}
-	createdbp, err := s.debugger.CreateBreakpoint(&arg.Breakpoint, arg.LocExpr, arg.SubstitutePathRules, arg.Suspended)
-	if err != nil {
+	createdbp, err := s.debugger.CreateBreakpoint(&arg.Breakpoint, arg.LocExpr, arg.SubstitutePathRules, arg.Suspended, nil)
+	if err != nil && err.Error() != "suspended breakpoint" {
 		return err
 	}
 	out.Breakpoint = *createdbp


### PR DESCRIPTION
Unsuspend Callback can be called when stopping at a breakpoint.

It looks good for a user to see suspended breakpoints are unsuspended after `plugin.Open`, so I leave triggering callback in `pluginOpenCallback` there.
